### PR TITLE
Support custom objects in EDW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [0.2.0] - Updating API to support JSON response of custom objects
+
 ## [0.1.7+1] - Correcting screenshots in readme
 
 ## [0.1.7] - Adding screenshots to readme, updating example project

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ An Enhanced Dropdown Widget (or EDW), is based on flutter's dropdown widget, but
 
 - In case you are relying on an external source to provide the data for the dropdown, you can pass in the url to fetch that data
 
-**Please be aware that currently, the parsing of the url is in JSON and only valid for key-value pairs that are in String format and type**
+- If you want to use a custom object as your data for the EDW, **you must**:
+    - Implement the toJson and fromJson methods inside of your class (see person.dart for reference)
+        - If not, an exception will be thrown when parsing the data for the EDW
+    - Pass in the desired field to show in the dropdown using fieldToPresent
 
-- If you want to use a custom object as your data for the EDW, you must implement the toJson and fromJson methods inside of your class (see person.dart for reference)
-    - If not, an exception will be thrown when parsing the data for the EDW
-
-### Instantiating an EDW can be done in three ways:
+### Instantiating an EDW can be done in two ways:
 
 1. The data source can be an endpoint (of Uri type)
 
@@ -50,11 +50,11 @@ EnhancedDropDown.withEndpoint(
                })
 ```
 
-3. The data source can be a custom object
+To give an example of the aforementioned usage of a custom object in your data, you need to use the **fieldToPresent** argument.
 
 ```
-EnhancedDropDown.withDataObject(
-                dropdownLabelTitle: "My People",
+EnhancedDropDown.withData(
+                dropdownLabelTitle: "EDW With Data Object",
                 dataSource: [new Person("First", "Last", 10),
                               new Person("Last", "First", 20)],
                 defaultOptionText: "Choose Person",
@@ -63,6 +63,8 @@ EnhancedDropDown.withDataObject(
                 },
                 fieldToPresent: "firstName")
 ```
+
+You can see the implementation of Person inside the example project
 
 ![Widget Screenshot 1](https://github.com/TomerPacific/enhanced_drop_down/blob/master/graphics/screenshot_1.png?raw=true)
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ An Enhanced Dropdown Widget (or EDW), is based on flutter's dropdown widget, but
 
 **Please be aware that currently, the parsing of the url is in JSON and only valid for key-value pairs that are in String format and type**
 
+- If you want to use a custom object as your data for the EDW, you must implement the toJson and fromJson methods inside of your class (see person.dart for reference)
+    - If not, an exception will be thrown when parsing the data for the EDW
 
-### Instantiating an EDW can be done in two ways:
+### Instantiating an EDW can be done in three ways:
 
 1. The data source can be an endpoint (of Uri type)
 
@@ -36,7 +38,7 @@ EnhancedDropDown.withEndpoint(
             })
 ```
 
-2. The data source can be a list of items
+2. The data source can be a list of items (of String type)
 
 ```
  EnhancedDropDown.withData(
@@ -46,6 +48,20 @@ EnhancedDropDown.withEndpoint(
                 valueReturned: (chosen) {
                    print(chosen);
                })
+```
+
+3. The data source can be a custom object
+
+```
+EnhancedDropDown.withDataObject(
+                dropdownLabelTitle: "My People",
+                dataSource: [new Person("First", "Last", 10),
+                              new Person("Last", "First", 20)],
+                defaultOptionText: "Choose Person",
+                valueReturned: (chosen) {
+                  print(chosen);
+                },
+                fieldToPresent: "firstName")
 ```
 
 ![Widget Screenshot 1](https://github.com/TomerPacific/enhanced_drop_down/blob/master/graphics/screenshot_1.png?raw=true)

--- a/example/enhanced_drop_down_example/lib/main.dart
+++ b/example/enhanced_drop_down_example/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:enhanced_drop_down_example/person.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'dart:convert' as convert;
@@ -59,15 +60,24 @@ class _MyHomePageState extends State<MyHomePage> {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            // EnhancedDropDown.withData(
-            //     dropdownLabelTitle: "My Things",
-            //     dataSource: ["A", "B"],
-            //     defaultOptionText: "A",
-            //     valueReturned: (chosen) {
-            //       print(chosen);
-            //     })
+            EnhancedDropDown.withDataObject(
+                dropdownLabelTitle: "EDW With Data Object",
+                dataSource: [new Person("First", "Last", 10),
+                              new Person("Last", "First", 20)],
+                defaultOptionText: "Choose Person",
+                valueReturned: (chosen) {
+                  print(chosen);
+                },
+                fieldToPresent: "firstName"),
+            EnhancedDropDown.withData(
+                dropdownLabelTitle: "EDW With Data",
+                dataSource: ["A", "B"],
+                defaultOptionText: "A",
+                valueReturned: (chosen) {
+                  print(chosen);
+                }),
            EnhancedDropDown.withEndpoint(
-            dropdownLabelTitle: "My Things",
+            dropdownLabelTitle: "EDW With Endpoint",
             defaultOptionText: "Choose",
             urlToFetchData: Uri.https("run.mocky.io","/v3/babc0845-8163-4f1e-80df-9bcabd3d4c43"),
             valueReturned: (chosen) {

--- a/example/enhanced_drop_down_example/lib/main.dart
+++ b/example/enhanced_drop_down_example/lib/main.dart
@@ -82,7 +82,15 @@ class _MyHomePageState extends State<MyHomePage> {
             urlToFetchData: Uri.https("run.mocky.io","/v3/babc0845-8163-4f1e-80df-9bcabd3d4c43"),
             valueReturned: (chosen) {
               print(chosen);
-            })
+            }),
+            EnhancedDropDown.withEndpoint(
+                dropdownLabelTitle: "EDW With Endpoint And Object",
+                defaultOptionText: "Choose",
+                urlToFetchData: Uri.https("run.mocky.io","/v3/cf19bc4e-fed5-4e95-9282-7a46cf24c505"),
+                valueReturned: (chosen) {
+                  print(chosen);
+            },
+            fieldToPresent: "firstName")
       ],
       ),
       )

--- a/example/enhanced_drop_down_example/lib/main.dart
+++ b/example/enhanced_drop_down_example/lib/main.dart
@@ -60,7 +60,7 @@ class _MyHomePageState extends State<MyHomePage> {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            EnhancedDropDown.withDataObject(
+            EnhancedDropDown.withData(
                 dropdownLabelTitle: "EDW With Data Object",
                 dataSource: [new Person("First", "Last", 10),
                               new Person("Last", "First", 20)],

--- a/example/enhanced_drop_down_example/lib/main.dart
+++ b/example/enhanced_drop_down_example/lib/main.dart
@@ -70,21 +70,21 @@ class _MyHomePageState extends State<MyHomePage> {
                 },
                 fieldToPresent: "firstName"),
             EnhancedDropDown.withData(
-                dropdownLabelTitle: "EDW With Data",
+                dropdownLabelTitle: "EDW With Data (String)",
                 dataSource: ["A", "B"],
                 defaultOptionText: "A",
                 valueReturned: (chosen) {
                   print(chosen);
                 }),
            EnhancedDropDown.withEndpoint(
-            dropdownLabelTitle: "EDW With Endpoint",
+            dropdownLabelTitle: "EDW With Endpoint (One Object)",
             defaultOptionText: "Choose",
             urlToFetchData: Uri.https("run.mocky.io","/v3/babc0845-8163-4f1e-80df-9bcabd3d4c43"),
             valueReturned: (chosen) {
               print(chosen);
             }),
             EnhancedDropDown.withEndpoint(
-                dropdownLabelTitle: "EDW With Endpoint And Object",
+                dropdownLabelTitle: "EDW With Endpoint Object (List of Objects)",
                 defaultOptionText: "Choose",
                 urlToFetchData: Uri.https("run.mocky.io","/v3/cf19bc4e-fed5-4e95-9282-7a46cf24c505"),
                 valueReturned: (chosen) {

--- a/example/enhanced_drop_down_example/lib/person.dart
+++ b/example/enhanced_drop_down_example/lib/person.dart
@@ -1,0 +1,25 @@
+class Person {
+  String firstName;
+  String lastName;
+  int age;
+
+  Person(String _firstName, String _lastName, int _age) {
+    firstName = _firstName;
+    lastName = _lastName;
+    age = _age;
+  }
+
+  Person.fromJson(Map<String, dynamic> json) {
+    firstName = json["firstName"];
+    lastName = json["lastName"];
+    age = json["age"];
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = new Map<String, dynamic>();
+    data["firstName"] = firstName;
+    data["lastName"] = lastName;
+    data["age"] = age;
+    return data;
+  }
+}

--- a/lib/enhanced_drop_down.dart
+++ b/lib/enhanced_drop_down.dart
@@ -9,27 +9,20 @@ class EnhancedDropDown extends StatefulWidget {
 
   ///Constructor that accepts a list of elements to be the data source for the dropdown
   EnhancedDropDown.withData(
-      {required this.dropdownLabelTitle,
-      required this.dataSource,
-      required this.defaultOptionText,
-      required this.valueReturned})
-      : urlToFetchData = null, fieldToPresent = null;
+      { required this.dropdownLabelTitle,
+        required this.dataSource,
+        required this.defaultOptionText,
+        required this.valueReturned,
+        this.fieldToPresent }
+      ) : urlToFetchData = null;
 
   ///Constructor that accepts an endpoint in URI form to fetch the data from
   EnhancedDropDown.withEndpoint(
-      {required this.dropdownLabelTitle,
-      required this.defaultOptionText,
-      required this.urlToFetchData,
-      required this.valueReturned})
-      : dataSource = null, fieldToPresent = null;
-
-  EnhancedDropDown.withDataObject(
-  {required this.dropdownLabelTitle,
-    required this.defaultOptionText,
-    required this.dataSource,
-    required this.valueReturned,
-    required this.fieldToPresent,
-  }): urlToFetchData = null;
+      { required this.dropdownLabelTitle,
+        required this.defaultOptionText,
+        required this.urlToFetchData,
+        required this.valueReturned }
+      ) : dataSource = null, fieldToPresent = null;
 
   /// Holds the default text to show when nothing is selected in the dropdown
   final String defaultOptionText;
@@ -43,7 +36,7 @@ class EnhancedDropDown extends StatefulWidget {
   /// A list which holds the data if we don't want to make a network request
   final List<dynamic>? dataSource;
 
-  final dynamic fieldToPresent;
+  final String? fieldToPresent;
 
   @override
   _EnhancedDropDownState createState() => _EnhancedDropDownState();

--- a/lib/enhanced_drop_down.dart
+++ b/lib/enhanced_drop_down.dart
@@ -70,15 +70,15 @@ class _EnhancedDropDownState extends State<EnhancedDropDown> {
             })
         );
       } else if (widget.dataSource != null) {
-      for (int i = 0; i < widget.dataSource!.length; i++) {
-        String dropdownValue = _getDropdownValue(widget.dataSource![i], false);
-        menuItems.add(
-            new DropdownMenuItem(
-                child:
-                  new Text(dropdownValue),
-                value:  dropdownValue)
-        );
-      }
+          for (int i = 0; i < widget.dataSource!.length; i++) {
+            String dropdownValue = _getDropdownValue(widget.dataSource![i], false);
+            menuItems.add(
+                new DropdownMenuItem(
+                    child:
+                      new Text(dropdownValue),
+                    value:  dropdownValue)
+            );
+        }
       setState(() {
         _data = menuItems;
       });
@@ -142,10 +142,10 @@ class _EnhancedDropDownState extends State<EnhancedDropDown> {
     return menuItems;
   }
 
-  String _getDropdownValue(dynamic itemData, bool isFromList) {
+  String _getDropdownValue(dynamic itemData, bool isElementPartOfList) {
     String dropdownValue;
     if (widget.fieldToPresent != null) {
-      if (isFromList) {
+      if (isElementPartOfList) {
         dropdownValue = itemData[widget.fieldToPresent];
       } else {
         try {

--- a/lib/enhanced_drop_down.dart
+++ b/lib/enhanced_drop_down.dart
@@ -83,8 +83,7 @@ class _EnhancedDropDownState extends State<EnhancedDropDown> {
           _data = menuItems;
         });
       } else {
-        print(
-            "EnhancedDropDownWidget Request failed with status: ${response.statusCode}.");
+        print("EnhancedDropDownWidget Request failed with status: ${response.statusCode}.");
       }
     } else if (widget.dataSource != null) {
       for (int i = 0; i < widget.dataSource!.length; i++) {

--- a/lib/enhanced_drop_down.dart
+++ b/lib/enhanced_drop_down.dart
@@ -64,35 +64,12 @@ class _EnhancedDropDownState extends State<EnhancedDropDown> {
     ));
 
     if (widget.urlToFetchData != null) {
-      var response = await http.get(widget.urlToFetchData!);
-      if (response.statusCode == 200) {
-       dynamic jsonResponse = convert.jsonDecode(response.body);
-       if (jsonResponse is List<dynamic>) {
-         for (final item in jsonResponse) {
-           String dropdownItemData = _getDropdownValue(item, true);
-           menuItems.add(
-               new DropdownMenuItem(
-                 child: new Text(dropdownItemData),
-                 value: dropdownItemData,
-               ));
-         }
-       } else if (jsonResponse is Map<String, dynamic>) {
-         jsonResponse.forEach((key, value) {
-             String dropdownItemData = _getDropdownValue(value, false);
-             menuItems.add(
-                 new DropdownMenuItem(
-                   child: new Text(dropdownItemData),
-                   value: dropdownItemData,
-                 ));
-           });
-       }
-        setState(() {
-          _data = menuItems;
-        });
-      } else {
-        print("EnhancedDropDownWidget Request failed with status: ${response.statusCode}.");
-      }
-    } else if (widget.dataSource != null) {
+        _fetchAndParseData(widget.urlToFetchData!, menuItems).then((value) =>
+            setState(() {
+              _data = value;
+            })
+        );
+      } else if (widget.dataSource != null) {
       for (int i = 0; i < widget.dataSource!.length; i++) {
         String dropdownValue = _getDropdownValue(widget.dataSource![i], false);
         menuItems.add(
@@ -131,6 +108,38 @@ class _EnhancedDropDownState extends State<EnhancedDropDown> {
             ],
           ));
     }
+  }
+
+  Future<List<DropdownMenuItem<dynamic>>> _fetchAndParseData(
+      Uri url,
+      List<DropdownMenuItem<dynamic>> menuItems) async {
+    var response = await http.get(url);
+    if (response.statusCode == 200) {
+      dynamic jsonResponse = convert.jsonDecode(response.body);
+      if (jsonResponse is List<dynamic>) {
+        for (final item in jsonResponse) {
+          String dropdownItemData = _getDropdownValue(item, true);
+          menuItems.add(
+              new DropdownMenuItem(
+                child: new Text(dropdownItemData),
+                value: dropdownItemData,
+              ));
+        }
+      } else if (jsonResponse is Map<String, dynamic>) {
+        jsonResponse.forEach((key, value) {
+          String dropdownItemData = _getDropdownValue(value, false);
+          menuItems.add(
+              new DropdownMenuItem(
+                child: new Text(dropdownItemData),
+                value: dropdownItemData,
+              ));
+        });
+      }
+    } else {
+      print("EnhancedDropDownWidget Request failed with status: ${response.statusCode}.");
+    }
+
+    return menuItems;
   }
 
   String _getDropdownValue(dynamic itemData, bool isFromList) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.1"
   charcode:
     dependency: transitive
     description:
@@ -35,21 +35,21 @@ packages:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -80,21 +80,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.12"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   pedantic:
     dependency: transitive
     description:
@@ -113,7 +120,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -134,21 +141,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.12"
   typed_data:
     dependency: transitive
     description:
@@ -162,6 +169,6 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: enhanced_drop_down
 description: A completely customizable drop down widget that comes with a label built in. You can customize the label, the data, the default value and more.
-version: 0.1.7+1
+version: 0.2.0
 homepage: https://github.com/TomerPacific
 
 environment:


### PR DESCRIPTION
Fixes #2 

To allow for custom objects to be part of the data passed into EDW, a new argument was exposed called, **fieldToPresent**.
This has been added as an optional argument to both constructors.

Logic was also added to support data returned in the shape of list of objects or one objects with many fields.

The example project was updated accordingly.