### PR TITLE
EDW upgrading compile/target sdk to 35

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    compileSdkVersion 34
+    compileSdkVersion 35
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -33,7 +33,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.tomerpacific.enhanced_drop_down_example"
         minSdkVersion flutter.minSdkVersion
-        targetSdkVersion 34
+        targetSdkVersion 35
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }


### PR DESCRIPTION
Resolves #54 

This pull request updates the Android SDK versions used in the `example/android/app/build.gradle` file to ensure compatibility with the latest Android platform requirements.

Android SDK version updates:

* Increased `compileSdkVersion` from 34 to 35 to support the latest Android features and APIs.
* Increased `targetSdkVersion` from 34 to 35 to target the latest Android platform for app deployment and behavior.