### PR TITLE
Correcting version of http package in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [0.4.1+0]
-  * Upgrading http package to 1.0.5
+  * Upgrading http package to 1.5.0
   * Upgrading example application (AGP, Gradle, Compile/Target SDK)
 
 ## [0.4.0+3]


### PR DESCRIPTION
Fixes #59 

This pull request updates the `CHANGELOG.md` to reflect a dependency upgrade.

* Dependency Updates:
  * Updated the `http` package version from 1.0.5 to 1.5.0 in the changelog entry for version 0.4.1+0.