### PR TITLE
EDW correcting endpoint in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ An Enhanced Dropdown Widget (or EDW), is based on flutter's dropdown widget, but
 EnhancedDropDown.withEndpoint(
             dropdownLabelTitle: "My Things",
             defaultOptionText: "Choose",
-            urlToFetchData: Uri.https("run.mocky.io","/v3/babc0845-8163-4f1e-80df-9bcabd3d4c43"),
+            urlToFetchData: Uri.https(
+                    "raw.githubusercontent.com",
+                    "/TomerPacific/enhanced_drop_down/refs/heads/master/example/personList.json"
+                    ),
             valueReturned: (chosen) {
               print(chosen);
             })


### PR DESCRIPTION
Resolves #64 

This pull request updates the data source used in the example for `EnhancedDropDown.withEndpoint` in the `README.md` file. The URL for fetching dropdown data now points to a JSON file hosted on GitHub instead of the previous mock API.

* Documentation update:
  * Changed the `urlToFetchData` example in the `README.md` to use a GitHub-hosted JSON file instead of a Mocky API endpoint.