### PR TITLE
EDW upgrading min dart sdk version to 3.5

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -63,7 +63,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.0+3"
+    version: "0.4.1+1"
   fake_async:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ">=3.5.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.4.1+1
 homepage: https://github.com/TomerPacific
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ">=3.5.0 <4.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Resolves #63 

This pull request updates the Dart SDK version requirement in both the main package and the example project to ensure compatibility with newer versions of the Dart SDK.

Dependency updates:

* Updated the Dart SDK environment constraint in `pubspec.yaml` from `">=3.0.0 <4.0.0"` to `">=3.5.0 <4.0.0"` to require at least Dart 3.5.0.
* Updated the Dart SDK environment constraint in `example/pubspec.yaml` from `">=3.0.0 <4.0.0"` to `">=3.5.0 <4.0.0"` for the example project.